### PR TITLE
.gitignoreにプライベート設定ファイルを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,10 @@ cython_debug/
 
 # Japanese documentation (for internal review only)
 *_ja.md
+
+# Git-dotfiles managed files
+.claude
+CLAUDE.md
+
+# Serena MCP
+.serena/


### PR DESCRIPTION
## 概要
.gitignoreにgit-dotfiles管理ファイルとSerena MCPのプライベート設定を追加します。

## 変更内容
- `.claude` ディレクトリを除外
- `CLAUDE.md` ファイルを除外
- `.serena/` ディレクトリを除外

## 理由
これらはプライベート設定ファイルであり、リポジトリに含めるべきではありません。

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)