### PR TITLE
Remove broken link to gitignored Japanese docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Check out the [full video](https://www.youtube.com/watch?v=Ns89YuE5-to) where yo
 ## Documentation
 
 - **[Specification (English)](docs/SPECIFICATION.md)** - Complete technical specification
-- **[仕様書（日本語）](docs/SPECIFICATION_ja.md)** - 完全な技術仕様書
 - **[E2E Test Guide](MaxMSP_Agent/test/E2E_TEST_GUIDE.md)** - End-to-end testing guide
 - **[Original README](README_ORIGINAL.md)** - Original project README
 


### PR DESCRIPTION
## 概要
README.mdから.gitignoreで除外されている日本語ドキュメントへのリンクを削除します。

## 変更内容
- `docs/SPECIFICATION_ja.md` へのリンクを削除（35行目）

## 理由
`.gitignore`で`*_ja.md`を除外しているため、これらのファイルはリポジトリに含まれず、リンクが機能しません。

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)